### PR TITLE
Removing titles for consistency with other names

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -11,9 +11,9 @@ The Web We Want is a collective effort by browser makers to understand where the
 ## Team
 
 * [Marcos Cáceres](https://twitter.com/marcosc) (Mozilla, W3C)
-* [Stephanie Drescher](https://twitter.com/seaotta) (Microsoft) — Program Manager
+* [Stephanie Drescher](https://twitter.com/seaotta) (Microsoft)
 * [Diego González](https://twitter.com/diekus) (Samsung)
-* [Aaron Gustafson](https://twitter.com/aarongustafson) (Microsoft) — Project Founder
+* [Aaron Gustafson](https://twitter.com/aarongustafson) (Microsoft)
 * [Brian Kardell](https://twitter.com/briankardell) (Igalia)
 * [Chris Wilson](https://twitter.com/cwilso) (Google, W3C)
 


### PR DESCRIPTION
A pretty simple change that simply removes the titles of the MS folks on the about page to bring consistency with the other names on the list of contributors.